### PR TITLE
Usiamo str come dtype delle stringhe

### DIFF
--- a/aggrega_dati.py
+++ b/aggrega_dati.py
@@ -115,8 +115,8 @@ def carica_asl():
     colonne = ['CODICE AZIENDA', 'DENOMINAZIONE AZIENDA', 'CODICE COMUNE']
     ifile = Path("data") / ("asl_piemonte.csv")
     asl = pd.read_csv(ifile, sep=";",
-                      dtype={"CODICE COMUNE": "string",
-                             "CODICE AZIENDA": "string"},
+                      dtype={"CODICE COMUNE": "str",
+                             "CODICE AZIENDA": "str"},
                       usecols=colonne)
     return asl
 
@@ -147,13 +147,13 @@ def carica_dati_da_regione_piemonte():
     # il primo file ha anche le informazione sul numero abitanti per comune
     print(ifiles[0])
     dfall = pd.read_csv(ifiles[0], sep=";",
-                        dtype={"Codice ISTAT": "string"})
+                        dtype={"Codice ISTAT": "str"})
 
     # carica i file con i dati
     for ifile in ifiles[1:]:
         print(ifile)
         df1 = pd.read_csv(ifile, sep=";",
-                          dtype={"Codice ISTAT": "string"})
+                          dtype={"Codice ISTAT": "str"})
         dfall = pd.concat([dfall, df1], axis=0)
         del df1
     print("Numero righe comuni ", dfall.shape[0])

--- a/evidenzia_incrementi_anomali_positivi.py
+++ b/evidenzia_incrementi_anomali_positivi.py
@@ -41,7 +41,7 @@ def main():
     # il primo file ha anche le informazione sul numero abitanti per comune
     print(ifiles[0])
     df = pd.read_csv(ifiles[0], sep=";",
-                     dtype={"Codice ISTAT": "string"})
+                     dtype={"Codice ISTAT": "str"})
     popolazione = df[['Abitanti', 'Codice ISTAT']] \
         .drop_duplicates(keep='first')
 
@@ -49,7 +49,7 @@ def main():
     for ifile in ifiles[1:]:
         print(ifile)
         df1 = pd.read_csv(ifile, sep=";",
-                          dtype={"Codice ISTAT": "string"})
+                          dtype={"Codice ISTAT": "str"})
         df = pd.concat([df, df1], axis=0)
         del df1
 

--- a/ordina_per_positivi_su_1000_abitanti.py
+++ b/ordina_per_positivi_su_1000_abitanti.py
@@ -30,7 +30,7 @@ def main():
 
     # crea il dataframe a partire dal file in input
     casi = pd.read_csv(args.positivi_per_comune, sep=";",
-                       dtype={"Codice ISTAT": "string"})
+                       dtype={"Codice ISTAT": "str"})
     fname = Path(args.positivi_per_comune).stem
     fdata = fname.replace("dati_", "") \
                  .replace("_da_regione_piemonte", "")
@@ -38,7 +38,7 @@ def main():
     # relativa al numero di abitanti per ogni comune
     ifile = Path("data") / "dati_2020_04_09_da_regione_piemonte.csv"
     df = pd.read_csv(ifile, sep=";",
-                     dtype={"Codice ISTAT": "string"})
+                     dtype={"Codice ISTAT": "str"})
     popolazione = df[['Abitanti', 'Codice ISTAT']] \
         .drop_duplicates(keep='first')
     # aggiungi la colonna 'Abitanti' al dataset


### PR DESCRIPTION
Pandas 0.25.3 su python3.8 non apprezza string al suo posto:

```
File "/usr/lib/python3/dist-packages/pandas/core/dtypes/common.py", line 2055, in pandas_dtype
    raise TypeError("data type '{}' not understood".format(dtype))
TypeError: data type 'string' not understood
```